### PR TITLE
Add config to connect to edge and chrome debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,14 +28,14 @@
           "type": "edge",
           "request": "attach",
           "name": "Attach to Microsoft Edge",
-          "port": 2015,
+          "port": 9222,
           "webRoot": "${workspaceFolder}"
         },
         {
           "type": "chrome",
           "request": "attach",
           "name": "Attach to Chrome",
-          "port": 2016,
+          "port": 9222,
           "webRoot": "${workspaceFolder}"
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,20 @@
             "console": "integratedTerminal",
             "sourceMaps": false,
             "outFiles": []
+        },
+        {
+          "type": "edge",
+          "request": "attach",
+          "name": "Attach to Microsoft Edge",
+          "port": 2015,
+          "webRoot": "${workspaceFolder}"
+        },
+        {
+          "type": "chrome",
+          "request": "attach",
+          "name": "Attach to Chrome",
+          "port": 2016,
+          "webRoot": "${workspaceFolder}"
         }
     ]
 }


### PR DESCRIPTION
Add config to connect VS Code debugger to running SPA when running in a browser that uses the Chrome DevTools Protocol.

https://github.com/Microsoft/vscode-chrome-debug
https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge

![image](https://user-images.githubusercontent.com/5880556/63053082-e362ca00-beae-11e9-9fdb-22c88166fd6d.png)
